### PR TITLE
Combine the loops for masked and separately-weighted model sets

### DIFF
--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -543,21 +543,39 @@ class LinearLSQFitter(metaclass=_FitterMeta):
 
         masked = np.any(np.ma.getmask(rhs))
 
-        if weights is not None and weights.ndim > 1:
+        if ((masked and len(model_copy) > 1) or
+            (weights is not None and weights.ndim > 1)):
 
-            # separate weights for multiple models case: Numpy's lstsq
-            # supports multiple dimensions only for rhs, so we need to loop
-            # manually on the models.  This may be fixed in the future with
-            # https://github.com/numpy/numpy/pull/15777
+            # Separate masks or weights for multiple models case: Numpy's
+            # lstsq supports multiple dimensions only for rhs, so we need to
+            # loop manually on the models. This may be fixed in the future
+            # with https://github.com/numpy/numpy/pull/15777.
 
-            scl = scl.T
-            lacoef = np.zeros(lhs.shape[-2:], dtype=rhs.dtype)
+            # Initialize empty array of coefficients and populate it one model
+            # at a time. The shape matches the number of coefficients from the
+            # Vandermonde matrix and the number of models from the RHS:
+            lacoef = np.zeros(lhs.shape[1:2] + rhs.shape[-1:], dtype=rhs.dtype)
 
-            for model_lhs, model_rhs, model_lacoef in zip(lhs.T, rhs.T, lacoef.T):
+            # Arrange the lhs as a stack of 2D matrices that we can iterate
+            # over to get the correctly-orientated lhs for each model:
+            if lhs.ndim > 2:
+                lhs_stack = np.rollaxis(lhs, -1, 0)
+            else:
+                lhs_stack = np.broadcast_to(lhs, rhs.shape[-1:] + lhs.shape)
+
+            # Loop over the models and solve for each one. By this point, the
+            # model set axis is the second of two. Transpose rather than using,
+            # say, np.moveaxis(array, -1, 0), since it's slightly faster and
+            # lstsq can't handle >2D arrays anyway. This could perhaps be
+            # optimized by collecting together models with identical masks
+            # (eg. those with no rejected points) into one operation, though it
+            # will still be relatively slow when calling lstsq repeatedly.
+            for model_lhs, model_rhs, model_lacoef in \
+                zip(lhs_stack, rhs.T, lacoef.T):
 
                 # Cull masked points on both sides of the matrix equation:
                 good = ~model_rhs.mask if masked else slice(None)
-                model_lhs = model_lhs.T[good]
+                model_lhs = model_lhs[good]
                 model_rhs = model_rhs[good][..., np.newaxis]
 
                 # Solve for this model:
@@ -565,7 +583,7 @@ class LinearLSQFitter(metaclass=_FitterMeta):
                                                              model_rhs, rcond)
                 model_lacoef[:] = t_coef.T
 
-        elif len(model_copy) == 1 or not masked:
+        else:
 
             # If we're fitting one or more models over a common set of points,
             # we only have to solve a single matrix equation, which is an order
@@ -577,38 +595,11 @@ class LinearLSQFitter(metaclass=_FitterMeta):
             lacoef, resids, rank, sval = np.linalg.lstsq(lhs[good],
                                                          rhs[good], rcond)
 
-        else:
-
-            # Where fitting multiple models with masked pixels, initialize an
-            # empty array of coefficients and populate it one model at a time.
-            # The shape matches the number of coefficients from the Vandermonde
-            # matrix and the number of models from the RHS:
-            lacoef = np.zeros(lhs.shape[-1:] + rhs.shape[-1:], dtype=rhs.dtype)
-
-            # Loop over the models and solve for each one. By this point, the
-            # model set axis is the second of two. Transpose rather than using,
-            # say, np.moveaxis(array, -1, 0), since it's slightly faster and
-            # lstsq can't handle >2D arrays anyway. This could perhaps be
-            # optimized by collecting together models with identical masks
-            # (eg. those with no rejected points) into one operation, though it
-            # will still be relatively slow when calling lstsq repeatedly.
-            for model_rhs, model_lacoef in zip(rhs.T, lacoef.T):
-
-                # Cull masked points on both sides of the matrix equation:
-                good = ~model_rhs.mask
-                model_lhs = lhs[good]
-                model_rhs = model_rhs[good][..., np.newaxis]
-
-                # Solve for this model:
-                t_coef, resids, rank, sval = np.linalg.lstsq(model_lhs,
-                                                             model_rhs, rcond)
-                model_lacoef[:] = t_coef.T
-
         self.fit_info['residuals'] = resids
         self.fit_info['rank'] = rank
         self.fit_info['singular_values'] = sval
 
-        lacoef = (lacoef.T / scl).T
+        lacoef /= scl[:, np.newaxis] if scl.ndim < rhs.ndim else scl
         self.fit_info['params'] = lacoef
 
         # TODO: Only Polynomial models currently have an _order attribute;


### PR DESCRIPTION
... and avoid some extra transpositions.

OK, something dropped off my radar and I wanted to squeeze this in to complete my suggestions before finishing another job... Here's a possible way of combining the 2 loops for masked & separately-weighted model sets.

Some quick timings show that the performance doesn't change a lot. I think the loops may be a fraction of a percent slower in this version when fitting the rows or columns of a 3k x 2k image (eg. because multiple transpositions were faster than rollaxis), but the code is simpler. Fitting a single model of 2-3k points seems to be ~3% faster after I've got rid of some transpositions. You might also want to kick this around a bit before merging it? Thanks.

cc: @nden

PS. I did also have an idea for speeding up this loop by splitting some of the underlying LAPACK code out of `np.linalg.lstsq`, but from your comment it looks like there may be an easier solution coming upstream.